### PR TITLE
package.json: fix typo in requirements (Node.js>=1.12, not npm>=1.12)

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,6 @@
   },
   "engineStrict": true,
   "engines": {
-    "npm": ">= 12.0.0"
+    "node": ">= 12.0.0"
   }
 }


### PR DESCRIPTION
This fixes a warning during "npm install":
```
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: '@subspace/jump-consistent-hash@1.1.1',
npm WARN EBADENGINE   required: { npm: '>= 12.0.0' },
npm WARN EBADENGINE   current: { node: 'v14.18.1', npm: '8.3.0' }
npm WARN EBADENGINE }
```